### PR TITLE
CarpetX: Make I/O thread-safe

### DIFF
--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1071,9 +1071,9 @@ GHExt::PatchData::LevelData::GroupData::GroupData(
       freg = make_unique<amrex::FluxRegister>(
           gba, dm, ghext->patchdata.at(patch).amrcore->refRatio(level - 1),
           level, numvars);
-    } else {
-      fluxes.fill(-1);
     }
+  } else {
+    fluxes.fill(-1);
   }
 }
 

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -484,12 +484,8 @@ int OutputGH(const cGH *restrict cctkGH) {
                double(cctk_time), CCTK_RunTime());
 
   if (out_every > 0 && cctk_iteration % out_every == 0) {
-    vector<future<void> > tasks;
-    const auto launch = [&](const auto &fun) {
-      tasks.push_back(async(std::launch::async, fun));
-    };
 
-    launch([&]() { OutputMetadata(cctkGH); });
+    OutputMetadata(cctkGH);
 
     OutputNorms(cctkGH);
 
@@ -541,9 +537,6 @@ int OutputGH(const cGH *restrict cctkGH) {
     OutputTSVold(cctkGH);
 
     OutputTSV(cctkGH);
-
-    for (auto &task : tasks)
-      task.wait();
 
     // Describe all output files
     OutputMeta(cctkGH);

--- a/CarpetX/src/io.cxx
+++ b/CarpetX/src/io.cxx
@@ -24,7 +24,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <future>
 #include <regex>
 
 namespace CarpetX {


### PR DESCRIPTION
Remove multi-threading for I/O because no I/O routines are actually thread-safe.