### PR TITLE
Remove support for `index` grid function tags

### DIFF
--- a/TestArrayGroup/interface.ccl
+++ b/TestArrayGroup/interface.ccl
@@ -7,6 +7,6 @@ CCTK_REAL test_array[4] TYPE=array DIM=2 SIZE=5,6 DISTRIB=constant
   test1 test2 test3
 } "Test arrays for verifying CarpetX implementation of non-distributed array data"
 
-CCTK_REAL test_gf TYPE=gf TAGS='index={1 1 1}' "Test grid function for verifying CarpetX implementation of DynamicData"
+CCTK_REAL test_gf TYPE=gf CENTERING={CCC} "Test grid function for verifying CarpetX implementation of DynamicData"
 
 CCTK_REAL test_scalar TYPE=scalar "Test scalar for verifying CarpetX implementation of DynamicData"

--- a/TestNorms/interface.ccl
+++ b/TestNorms/interface.ccl
@@ -6,11 +6,11 @@ uses include header: loop.hxx
 
 private:
 
-CCTK_REAL gf000 TYPE=gf TAGS='index={0 0 0}' "Test grid function"
-CCTK_REAL gf001 TYPE=gf TAGS='index={0 0 1}' "Test grid function"
-CCTK_REAL gf010 TYPE=gf TAGS='index={0 1 0}' "Test grid function"
-CCTK_REAL gf011 TYPE=gf TAGS='index={0 1 1}' "Test grid function"
-CCTK_REAL gf100 TYPE=gf TAGS='index={1 0 0}' "Test grid function"
-CCTK_REAL gf101 TYPE=gf TAGS='index={1 0 1}' "Test grid function"
-CCTK_REAL gf110 TYPE=gf TAGS='index={1 1 0}' "Test grid function"
-CCTK_REAL gf111 TYPE=gf TAGS='index={1 1 1}' "Test grid function"
+CCTK_REAL gf000 TYPE=gf CENTERING={VVV} "Test grid function"
+CCTK_REAL gf001 TYPE=gf CENTERING={VVC} "Test grid function"
+CCTK_REAL gf010 TYPE=gf CENTERING={VCV} "Test grid function"
+CCTK_REAL gf011 TYPE=gf CENTERING={VCC} "Test grid function"
+CCTK_REAL gf100 TYPE=gf CENTERING={CVV} "Test grid function"
+CCTK_REAL gf101 TYPE=gf CENTERING={CVC} "Test grid function"
+CCTK_REAL gf110 TYPE=gf CENTERING={CCV} "Test grid function"
+CCTK_REAL gf111 TYPE=gf CENTERING={CCC} "Test grid function"

--- a/TestNorms/src/test.cc
+++ b/TestNorms/src/test.cc
@@ -28,50 +28,50 @@ CCTK_REAL fun(const Loop::PointDesc &p, const bool avgx, const bool avgy,
 }
 
 extern "C" void TestNorms_SetError(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_ARGUMENTSX_TestNorms_SetError;
   DECLARE_CCTK_PARAMETERS;
 
   Loop::loop_int<1, 1, 1>(cctkGH, [&](const Loop::PointDesc &p) {
     if (fabs(p.x) <= refined_radius && fabs(p.y) <= refined_radius &&
         fabs(p.z) <= refined_radius) {
-      regrid_error[p.idx] = 1;
+      regrid_error(p.I) = 1;
     } else {
-      regrid_error[p.idx] = 0;
+      regrid_error(p.I) = 0;
     }
   });
 }
 
 extern "C" void TestNorms_Set(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestNorms_Set;
   DECLARE_CCTK_PARAMETERS;
-  DECLARE_CCTK_ARGUMENTS;
 
   const int order = 3; // an order that is higher than linear so that the value
                        // at the cell center is not the same as the average
                        // over the cell
 
   Loop::loop_all<0, 0, 0>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf000[p.idx] = fun(p, 0, 0, 0, order);
+    gf000(p.I) = fun(p, 0, 0, 0, order);
   });
   Loop::loop_all<0, 0, 1>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf001[p.idx] = fun(p, 0, 0, 1, order);
+    gf001(p.I) = fun(p, 0, 0, 1, order);
   });
   Loop::loop_all<0, 1, 0>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf010[p.idx] = fun(p, 0, 1, 0, order);
+    gf010(p.I) = fun(p, 0, 1, 0, order);
   });
   Loop::loop_all<0, 1, 1>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf011[p.idx] = fun(p, 0, 1, 1, order);
+    gf011(p.I) = fun(p, 0, 1, 1, order);
   });
   Loop::loop_all<1, 0, 0>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf100[p.idx] = fun(p, 1, 0, 0, order);
+    gf100(p.I) = fun(p, 1, 0, 0, order);
   });
   Loop::loop_all<1, 0, 1>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf101[p.idx] = fun(p, 1, 0, 1, order);
+    gf101(p.I) = fun(p, 1, 0, 1, order);
   });
   Loop::loop_all<1, 1, 0>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf110[p.idx] = fun(p, 1, 1, 0, order);
+    gf110(p.I) = fun(p, 1, 1, 0, order);
   });
   Loop::loop_all<1, 1, 1>(cctkGH, [&](const Loop::PointDesc &p) {
-    gf111[p.idx] = fun(p, 1, 1, 1, order);
+    gf111(p.I) = fun(p, 1, 1, 1, order);
   });
 }
 


### PR DESCRIPTION
Use an official `centering` declaration instead.
