### PR TITLE
ODESolvers: Look for dependents in current thorn

### DIFF
--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -542,7 +542,7 @@ int get_group_rhs(const int gi) {
 
   auto str1 = str;
   if (str1.find(':') == std::string::npos) {
-    const char *impl = CCTK_GroupImplementationI(gi);
+    const char *const impl = CCTK_GroupImplementationI(gi);
     str1 = string(impl) + "::" + str1;
   }
   const int gi1 = CCTK_GroupIndex(str1.c_str());
@@ -583,11 +583,19 @@ std::vector<int> get_group_dependents(const int gi) {
     while (pos < str.size() && !std::isspace(str[pos]))
       ++pos;
     const std::size_t group_end = pos;
-    const std::string groupname =
-        str.substr(group_begin, group_end - group_begin);
-    const int gi = CCTK_GroupIndex(groupname.c_str());
-    assert(gi >= 0); // Check dependents are valid groups
-    dependents.push_back(gi);
+    std::string groupname = str.substr(group_begin, group_end - group_begin);
+    // If the group name does not contain a scope operator `::`, then
+    // prefix the current group's implementation name
+    if (groupname.find(':') == std::string::npos) {
+      const char *const impl = CCTK_GroupImplementationI(gi);
+      groupname = std::string(impl) + "::" + groupname;
+    }
+    const int dep_gi = CCTK_GroupIndex(groupname.c_str());
+    if (dep_gi < 0)
+      CCTK_VERROR("Variable group \"%s\" declares a dependent group \"%s\". "
+                  "That group does not exist.",
+                  CCTK_FullGroupName(gi), groupname.c_str());
+    dependents.push_back(dep_gi);
   }
 
   return dependents;

--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -546,7 +546,6 @@ int groupindex(const int other_gi, std::string gn) {
     gn = buf.str();
   }
   const int gi = CCTK_GroupIndex(gn.c_str());
-  assert(gi >= 0);
   return gi;
 }
 
@@ -570,6 +569,10 @@ int get_group_rhs(const int gi) {
     return -1; // No RHS specified
 
   const int rhs = groupindex(gi, str);
+  if (rhs < 0)
+    CCTK_VERROR("Variable group \"%s\" declares a RHS group \"%s\". "
+                "That group does not exist.",
+                CCTK_FullGroupName(gi), str.c_str());
   assert(rhs != gi);
 
   return rhs;


### PR DESCRIPTION
If the group name of a dependent does not contain a scope operator `::`, then prefix the current group's implementation name.