### PR TITLE
Removed duplicated scheduling

### DIFF
--- a/ADMBaseX/schedule.ccl
+++ b/ADMBaseX/schedule.ccl
@@ -12,31 +12,35 @@ SCHEDULE GROUP ADMBaseX_PostInitial AT initial AFTER (ADMBaseX_InitialData ADMBa
 {
 } "Schedule group for modifying the ADM initial data, such as e.g. adding noise"
 
-SCHEDULE GROUP ADMBaseX_SetADMVars AT postregrid
+if( CCTK_IsThornActive("ODESolvers") )
 {
-} "Set ADM variables in this group"
+  SCHEDULE GROUP ADMBaseX_SetADMVars IN ODESolvers_PostStep
+  {
+  } "Set ADM variables in this group"
 
-SCHEDULE GROUP ADMBaseX_SetADMVars AT poststep
+  SCHEDULE GROUP ADMBaseX_SetADMRHS IN ODESolvers_PostStep
+  {
+  } "Set ADM RHS variables in this group"  
+}
+else
 {
-} "Set ADM variables in this group"
+  # ODESolvers_PostStep is also scheduled AT postinitial and postrestrict
+  SCHEDULE GROUP ADMBaseX_SetADMVars AT postregrid
+  {
+  } "Set ADM variables in this group"
 
-SCHEDULE GROUP ADMBaseX_SetADMVars IN ODESolvers_PostStep
-{
-} "Set ADM variables in this group"
-
-SCHEDULE GROUP ADMBaseX_SetADMRHS AT postregrid
-{
-} "Set ADM RHS variables in this group"  
-
-SCHEDULE GROUP ADMBaseX_SetADMRHS AT poststep
-{
-} "Set ADM RHS variables in this group"  
-
-SCHEDULE GROUP ADMBaseX_SetADMRHS IN ODESolvers_PostStep
-{
-} "Set ADM RHS variables in this group"  
-
-
+  SCHEDULE GROUP ADMBaseX_SetADMVars AT poststep
+  {
+  } "Set ADM variables in this group"
+  
+  SCHEDULE GROUP ADMBaseX_SetADMRHS AT postregrid
+  {
+  } "Set ADM RHS variables in this group"  
+  
+  SCHEDULE GROUP ADMBaseX_SetADMRHS AT poststep
+  {
+  } "Set ADM RHS variables in this group"  
+}
 
 if (CCTK_EQUALS(initial_data, "Cartesian Minkowski")) {
   SCHEDULE ADMBaseX_initial_data IN ADMBaseX_InitialData

--- a/HydroBaseX/schedule.ccl
+++ b/HydroBaseX/schedule.ccl
@@ -8,19 +8,23 @@ SCHEDULE GROUP HydroBaseX_PostInitial AT initial AFTER HydroBaseX_InitialData
 {
 } "Schedule group for modifying the hydro initial data, such as e.g. adding noise"
 
-
-SCHEDULE GROUP HydroBaseX_SetHydroVars AT postregrid
+if( CCTK_IsThornActive("ODESolvers") )
 {
-} "Set hydro variables in this group, or before this group"
-
-SCHEDULE GROUP HydroBaseX_SetHydroVars AT poststep
+  SCHEDULE GROUP HydroBaseX_SetHydroVars IN ODESolvers_PostStep
+  {
+  } "Set hydro variables in this group, or before this group"
+}
+else
 {
-} "Set hydro variables in this group, or before this group"
+  # ODESolvers_PostStep is also scheduled AT postinitial and postrestrict
+  SCHEDULE GROUP HydroBaseX_SetHydroVars AT postregrid
+  {
+  } "Set hydro variables in this group, or before this group"
 
-SCHEDULE GROUP HydroBaseX_SetHydroVars IN ODESolvers_PostStep
-{
-} "Set hydro variables in this group, or before this group"
-
+  SCHEDULE GROUP HydroBaseX_SetHydroVars AT poststep
+  {
+  } "Set hydro variables in this group, or before this group"
+}
 
 
 if (CCTK_EQUALS(initial_hydro, "vacuum")) {

--- a/TmunuBaseX/schedule.ccl
+++ b/TmunuBaseX/schedule.ccl
@@ -4,17 +4,24 @@ SCHEDULE GROUP TmunuBaseX_SetTmunuVars AT initial AFTER ADMBaseX_SetADMVars
 {
 } "Schedule group for setting T_munu"
 
-SCHEDULE GROUP TmunuBaseX_SetTmunuVars AT postregrid AFTER ADMBaseX_SetADMVars
+if( CCTK_IsThornActive("ODESolvers") )
 {
-} "Schedule group for setting T_munu"
+  SCHEDULE GROUP TmunuBaseX_SetTmunuVars IN ODESolvers_PostStep AFTER ADMBaseX_SetADMVars
+  {
+  } "Schedule group for setting T_munu"
+}
+else
+{
+  # ODESolvers_PostStep is also scheduled AT postinitial and postrestrict
+  SCHEDULE GROUP TmunuBaseX_SetTmunuVars AT postregrid AFTER ADMBaseX_SetADMVars
+  {
+  } "Schedule group for setting T_munu"
 
-SCHEDULE GROUP TmunuBaseX_SetTmunuVars AT poststep AFTER ADMBaseX_SetADMVars
-{
-} "Schedule group for setting T_munu"
+  SCHEDULE GROUP TmunuBaseX_SetTmunuVars AT poststep AFTER ADMBaseX_SetADMVars
+  {
+  } "Schedule group for setting T_munu"
+}
 
-SCHEDULE GROUP TmunuBaseX_SetTmunuVars IN ODESolvers_PostStep AFTER ADMBaseX_SetADMVars
-{
-} "Schedule group for setting T_munu"
 
 
 


### PR DESCRIPTION
When ODESolvers is on (basically everything right now), several groups are double-scheduled in ADMBase, HydroBase, and TmunuBase. This simply puts in logic that switches their scheduling based on whether this thorn is active. If several thorns like ODESolvers eventually exist, then we might need to introduce a more elegant solution.