### PR TITLE
CarpetX: only multi-thread MFIter if AMReX supports it

### DIFF
--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1573,7 +1573,9 @@ void CactusAmrCore::ErrorEst(const int level, amrex::TagBoxArray &tags,
                    []() { return "ErrorEst"; });
   std::size_t npoints_set = 0, npoints_clear = 0, npoints_total = 0;
   auto mfitinfo = amrex::MFItInfo().SetDynamic(true).EnableTiling();
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
+#endif
   for (amrex::MFIter mfi(*leveldata.fab, mfitinfo); mfi.isValid(); ++mfi) {
     GridPtrDesc1 grid(leveldata, groupdata, mfi);
 

--- a/CarpetX/src/reduction.cxx
+++ b/CarpetX/src/reduction.cxx
@@ -201,7 +201,9 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
       // TODO: check that multi-threading actually helps (and we are
       // not dominated by memory latency)
       // TODO: document required version of OpenMP to use custom reductions
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(reduction : red)
+#endif
       for (amrex::MFIter mfi(mfab, mfitinfo); mfi.isValid(); ++mfi) {
         const amrex::Box &bx = mfi.tilebox(); // current tile (without ghosts)
         const vect<int, dim> tmin{bx.smallEnd(0), bx.smallEnd(1),

--- a/CarpetX/src/valid.cxx
+++ b/CarpetX/src/valid.cxx
@@ -485,7 +485,9 @@ calculate_checksums(const vector<vector<vector<valid_t> > > &will_write) {
   assert(active_levels);
   active_levels->loop([&](auto &restrict leveldata) {
     auto mfitinfo = amrex::MFItInfo().SetDynamic(true).EnableTiling();
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
+#endif
     for (amrex::MFIter mfi(*leveldata.fab, mfitinfo); mfi.isValid(); ++mfi) {
 
       for (const auto &groupdataptr : leveldata.groupdata) {
@@ -563,7 +565,9 @@ void check_checksums(const checksums_t &checksums,
   assert(active_levels);
   active_levels->loop([&](auto &restrict leveldata) {
     auto mfitinfo = amrex::MFItInfo().SetDynamic(true).EnableTiling();
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
+#endif
     for (amrex::MFIter mfi(*leveldata.fab, mfitinfo); mfi.isValid(); ++mfi) {
 
       for (const auto &groupdataptr : leveldata.groupdata) {


### PR DESCRIPTION
This adds a couple of `#ifdef AMP_USE_OPENMP` around `pragma omp parallel` to avoid calling AMReX functions from within OpenMP parallel sections if AMReX itself is not compiled with OpenMP support (and thus eg fails to check for nested MFIter instantiations only on a single thread).

The code that would trigger this is in AMReX `Src/Base/AMReX_MFIter.cpp`:

```
#ifdef AMREX_USE_OMP
#pragma omp master
#endif
    {
        ++depth;
        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(depth == 1 || MFIter::allow_multiple_mfiters,
            "Nested or multiple active MFIters is not supported by default.  This can be changed by calling MFIter::allowMultipleMFIters(true)".);
    }
```

and AMReX user code like this:

```
#pragma omp parallel
for(MFIter mfi(foo) ; ...)
```

will trigger the error since the `parallel` section causes a `MFIter` object to be created in each thread and without `AMREX_USE_OMP` AMReX will trigger the `depth == 1` test on all threads instead of just the master thread.