### PR TITLE
CarpetX: Remove superfluous enum value `symmetry_t::outer_boundary`

### DIFF
--- a/CarpetX/src/boundaries.cxx
+++ b/CarpetX/src/boundaries.cxx
@@ -30,9 +30,9 @@ BoundaryCondition::BoundaryCondition(
     const GHExt::PatchData::LevelData::GroupData &groupdata,
     const amrex::Box &box, amrex::FArrayBox &dest)
     : groupdata(groupdata), patchdata(ghext->patchdata.at(groupdata.patch)),
-      geom(patchdata.amrcore->Geom(groupdata.level)),
-      dest(dest), imin{geom.Domain().smallEnd(0), geom.Domain().smallEnd(1),
-                       geom.Domain().smallEnd(2)},
+      geom(patchdata.amrcore->Geom(groupdata.level)), dest(dest),
+      imin{geom.Domain().smallEnd(0), geom.Domain().smallEnd(1),
+           geom.Domain().smallEnd(2)},
       imax{geom.Domain().bigEnd(0) + 1 + !groupdata.indextype[0],
            geom.Domain().bigEnd(1) + 1 + !groupdata.indextype[1],
            geom.Domain().bigEnd(2) + 1 + !groupdata.indextype[2]},
@@ -251,8 +251,6 @@ void BoundaryCondition::apply() const {
             const symmetry_t symmetry = patchdata.symmetries[face][dir];
             const boundary_t boundary = groupdata.boundaries[face][dir];
             if ((symmetry == symmetry_t::none &&
-                 boundary == boundary_t::none) ||
-                (symmetry == symmetry_t::outer_boundary &&
                  boundary == boundary_t::none) ||
                 symmetry == symmetry_t::interpatch ||
                 symmetry == symmetry_t::periodic) {

--- a/CarpetX/src/boundaries_impl.hxx
+++ b/CarpetX/src/boundaries_impl.hxx
@@ -69,7 +69,6 @@ void BoundaryCondition::apply_on_face() const {
     const boundary_t boundary_x = groupdata.boundaries[f][0];
 
     if ((symmetry_x == symmetry_t::none && boundary_x == boundary_t::none) ||
-        (boundary_x == boundary_t::none) ||
         (symmetry_x == symmetry_t::interpatch &&
          boundary_x == boundary_t::none) ||
         symmetry_x == symmetry_t::periodic)
@@ -113,7 +112,6 @@ void BoundaryCondition::apply_on_face_symbcx(
     const boundary_t boundary_y = groupdata.boundaries[f][1];
 
     if ((symmetry_y == symmetry_t::none && boundary_y == boundary_t::none) ||
-        (boundary_y == boundary_t::none) ||
         (symmetry_y == symmetry_t::interpatch &&
          boundary_y == boundary_t::none) ||
         symmetry_y == symmetry_t::periodic)
@@ -158,7 +156,6 @@ void BoundaryCondition::apply_on_face_symbcxy(
     const boundary_t boundary_z = groupdata.boundaries[f][2];
 
     if ((symmetry_z == symmetry_t::none && boundary_z == boundary_t::none) ||
-        (boundary_z == boundary_t::none) ||
         (symmetry_z == symmetry_t::interpatch &&
          boundary_z == boundary_t::none) ||
         symmetry_z == symmetry_t::periodic)

--- a/CarpetX/src/boundaries_impl.hxx
+++ b/CarpetX/src/boundaries_impl.hxx
@@ -69,8 +69,7 @@ void BoundaryCondition::apply_on_face() const {
     const boundary_t boundary_x = groupdata.boundaries[f][0];
 
     if ((symmetry_x == symmetry_t::none && boundary_x == boundary_t::none) ||
-        (symmetry_x == symmetry_t::outer_boundary &&
-         boundary_x == boundary_t::none) ||
+        (boundary_x == boundary_t::none) ||
         (symmetry_x == symmetry_t::interpatch &&
          boundary_x == boundary_t::none) ||
         symmetry_x == symmetry_t::periodic)
@@ -114,8 +113,7 @@ void BoundaryCondition::apply_on_face_symbcx(
     const boundary_t boundary_y = groupdata.boundaries[f][1];
 
     if ((symmetry_y == symmetry_t::none && boundary_y == boundary_t::none) ||
-        (symmetry_y == symmetry_t::outer_boundary &&
-         boundary_y == boundary_t::none) ||
+        (boundary_y == boundary_t::none) ||
         (symmetry_y == symmetry_t::interpatch &&
          boundary_y == boundary_t::none) ||
         symmetry_y == symmetry_t::periodic)
@@ -160,8 +158,7 @@ void BoundaryCondition::apply_on_face_symbcxy(
     const boundary_t boundary_z = groupdata.boundaries[f][2];
 
     if ((symmetry_z == symmetry_t::none && boundary_z == boundary_t::none) ||
-        (symmetry_z == symmetry_t::outer_boundary &&
-         boundary_z == boundary_t::none) ||
+        (boundary_z == boundary_t::none) ||
         (symmetry_z == symmetry_t::interpatch &&
          boundary_z == boundary_t::none) ||
         symmetry_z == symmetry_t::periodic)

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -82,8 +82,6 @@ std::ostream &operator<<(std::ostream &os, const symmetry_t symmetry) {
   switch (symmetry) {
   case symmetry_t::none:
     return os << "none";
-  case symmetry_t::outer_boundary:
-    return os << "outer_boundary";
   case symmetry_t::interpatch:
     return os << "interpatch";
   case symmetry_t::periodic:
@@ -149,10 +147,10 @@ array<array<symmetry_t, dim>, 2> get_symmetries() {
   array<array<symmetry_t, dim>, 2> symmetries;
   for (int f = 0; f < 2; ++f)
     for (int d = 0; d < dim; ++d)
-      symmetries[f][d] = is_outer_boundary[f][d] ? symmetry_t::outer_boundary
+      symmetries[f][d] = is_outer_boundary[f][d] ? symmetry_t::none
                          : is_periodic[f][d]     ? symmetry_t::periodic
                          : is_reflection[f][d]   ? symmetry_t::reflection
-                                                 : symmetry_t::outer_boundary;
+                                                 : symmetry_t::none;
 
   return symmetries;
 }
@@ -164,8 +162,9 @@ array<array<boundary_t, dim>, 2> get_default_boundaries() {
   array<array<bool, 3>, 2> is_symmetry;
   for (int f = 0; f < 2; ++f)
     for (int d = 0; d < dim; ++d)
-      is_symmetry[f][d] = symmetries[f][d] != symmetry_t::none &&
-                          symmetries[f][d] != symmetry_t::outer_boundary;
+      is_symmetry[f][d] = symmetries[f][d] != symmetry_t::none
+          // && symmetries[f][d] != symmetry_t::outer_boundary
+          ;
 
   const array<array<bool, 3>, 2> is_dirichlet{{
       {{
@@ -243,8 +242,7 @@ array<array<boundary_t, dim>, 2> get_group_boundaries(const int gi) {
   array<array<bool, 3>, 2> is_symmetry;
   for (int f = 0; f < 2; ++f)
     for (int d = 0; d < dim; ++d)
-      is_symmetry[f][d] = symmetries[f][d] != symmetry_t::none &&
-                          symmetries[f][d] != symmetry_t::outer_boundary;
+      is_symmetry[f][d] = symmetries[f][d] != symmetry_t::none;
 
   array<array<boundary_t, dim>, 2> boundaries = get_default_boundaries();
 

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1829,12 +1829,13 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
             groupdata.all_faces_have_symmetries_or_boundaries()
                 ? make_valid_outer()
                 : valid_t();
-        assert(outer_valid == make_valid_outer());
         for (int vi = 0; vi < groupdata.numvars; ++vi) {
           groupdata.valid.at(tl).at(vi).set_all(
               make_valid_int() | make_valid_ghosts() | outer_valid,
               []() { return "MakeNewLevelFromCoarse after prolongation"; });
-          // check_valid(groupdata, vi, tl, nan_handling, []() {
+          // This cannot be called because it would access the data
+          // with old metadata
+          // check_valid(leveldata, groupdata, vi, tl, nan_handling, []() {
           //   return "MakeNewLevelFromCoarse after prolongation";
           // });
         }

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -208,7 +208,6 @@ struct GHExt {
     int patch;
 
     array<array<symmetry_t, dim>, 2> symmetries;
-    bool all_faces_have_symmetries() const;
 
     // AMReX grid structure
     // TODO: convert this from unique_ptr to optional
@@ -264,6 +263,7 @@ struct GHExt {
         array<int, dim> nghostzones;
 
         array<array<boundary_t, dim>, 2> boundaries;
+        bool all_faces_have_symmetries_or_boundaries() const;
         vector<array<int, dim> > parities;
         vector<CCTK_REAL> dirichlet_values;
         vector<CCTK_REAL> robin_values;

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -40,7 +40,6 @@ using rat64 = rational<int64_t>;
 // Symmetries are domain properties
 enum class symmetry_t {
   none,
-  outer_boundary,
   interpatch,
   periodic,
   reflection,
@@ -48,7 +47,7 @@ enum class symmetry_t {
 std::ostream &operator<<(std::ostream &os, const symmetry_t symmetry);
 
 // Boundary conditions are group properties. They are valid only for faces where
-// the domain symmetry is `outer_boundary`.
+// the domain symmetry is `none`.
 enum class boundary_t {
   none,
   symmetry_boundary,

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -117,11 +117,9 @@ GridDesc::GridDesc(const GHExt::PatchData::LevelData &leveldata,
   }
 
   // Boundaries
-  const auto &symmetries = ghext->patchdata.at(leveldata.patch).symmetries;
   for (int d = 0; d < dim; ++d)
     for (int f = 0; f < 2; ++f)
-      bbox[f][d] = vbx[orient(d, f)] == domain[orient(d, f)] &&
-                   symmetries[f][d] != symmetry_t::none;
+      bbox[f][d] = vbx[orient(d, f)] == domain[orient(d, f)];
 
   // Thread tile box
   for (int d = 0; d < dim; ++d) {

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -2268,36 +2268,35 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
                              ghext->patchdata.at(leveldata.patch)
                                  .amrcore->Geom(leveldata.level));
 
-          tasks1.emplace_back([&tasks2, &leveldata, &groupdata,
-                               have_multipatch_boundaries, nan_handling, tl,
-                               fillpatch_continue =
-                                   std::move(fillpatch_continue)]() {
-            auto fillpatch_finish = fillpatch_continue();
+          tasks1.emplace_back(
+              [&tasks2, &leveldata, &groupdata, nan_handling, tl,
+               fillpatch_continue = std::move(fillpatch_continue)]() {
+                auto fillpatch_finish = fillpatch_continue();
 
-            tasks2.emplace_back([&leveldata, &groupdata,
-                                 have_multipatch_boundaries, nan_handling, tl,
-                                 fillpatch_finish =
-                                     std::move(fillpatch_finish)]() {
-              fillpatch_finish();
+                tasks2.emplace_back(
+                    [&leveldata, &groupdata, nan_handling, tl,
+                     fillpatch_finish = std::move(fillpatch_finish)]() {
+                      fillpatch_finish();
 
-              for (int vi = 0; vi < groupdata.numvars; ++vi) {
-                groupdata.valid.at(tl).at(vi).set_ghosts(true, []() {
-                  return "SyncGroupsByDirI after syncing: "
-                         "Mark ghost zones as valid";
-                });
-                if (groupdata.all_faces_have_symmetries_or_boundaries())
-                  groupdata.valid.at(tl).at(vi).set_outer(true, []() {
-                    return "SyncGroupsByDirI after syncing: "
-                           "Mark outer boundaries as valid";
-                  });
-                poison_invalid(leveldata, groupdata, vi, tl);
-                if (!have_multipatch_boundaries)
-                  check_valid(leveldata, groupdata, vi, tl, nan_handling, []() {
-                    return "SyncGroupsByDirI after syncing";
-                  });
-              }
-            });
-          });
+                      for (int vi = 0; vi < groupdata.numvars; ++vi) {
+                        groupdata.valid.at(tl).at(vi).set_ghosts(true, []() {
+                          return "SyncGroupsByDirI after syncing: "
+                                 "Mark ghost zones as valid";
+                        });
+                        if (groupdata.all_faces_have_symmetries_or_boundaries())
+                          groupdata.valid.at(tl).at(vi).set_outer(true, []() {
+                            return "SyncGroupsByDirI after syncing: "
+                                   "Mark outer boundaries as valid";
+                          });
+                        poison_invalid(leveldata, groupdata, vi, tl);
+                        if (!have_multipatch_boundaries)
+                          check_valid(leveldata, groupdata, vi, tl,
+                                      nan_handling, []() {
+                                        return "SyncGroupsByDirI after syncing";
+                                      });
+                      }
+                    });
+              });
         } // for tl
 
       } else { // if leveldata.level > 0

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -2227,7 +2227,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
   std::vector<std::function<void()> > tasks1;
   std::vector<std::function<void()> > tasks2;
 
-  const bool have_multipatch_boundaries =
+  static const bool have_multipatch_boundaries =
       CCTK_IsFunctionAliased("MultiPatch_Interpolate");
 
   active_levels->loop([&](auto &restrict leveldata) {
@@ -2285,8 +2285,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
                   return "SyncGroupsByDirI after syncing: "
                          "Mark ghost zones as valid";
                 });
-                if (ghext->patchdata.at(leveldata.patch)
-                        .all_faces_have_symmetries())
+                if (groupdata.all_faces_have_symmetries_or_boundaries())
                   groupdata.valid.at(tl).at(vi).set_outer(true, []() {
                     return "SyncGroupsByDirI after syncing: "
                            "Mark outer boundaries as valid";
@@ -2359,8 +2358,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
                       return "SyncGroupsByDirI after prolongation: "
                              "Mark ghost zones as valid";
                     });
-                    if (ghext->patchdata.at(leveldata.patch)
-                            .all_faces_have_symmetries())
+                    if (groupdata.all_faces_have_symmetries_or_boundaries())
                       groupdata.valid.at(tl).at(vi).set_outer(true, []() {
                         return "SyncGroupsByDirI after prolongation: "
                                "Mark outer boundaries as valid";
@@ -2391,7 +2389,7 @@ int SyncGroupsByDirI(const cGH *restrict cctkGH, int numgroups,
   tasks2.clear();
   synchronize();
 
-  if (CCTK_IsFunctionAliased("MultiPatch_Interpolate")) {
+  if (have_multipatch_boundaries) {
     std::vector<CCTK_INT> cactusvarinds;
     for (int group : groups) {
       const auto &groupdata =


### PR DESCRIPTION
Also correct cctk_bbox near symmetry boundaries.