### PR TITLE
CarpetX: Rename function to MultiPatch_GlobalToLocal2

### DIFF
--- a/CarpetX/interface.ccl
+++ b/CarpetX/interface.ccl
@@ -140,7 +140,7 @@ PROVIDES FUNCTION Interpolate WITH CarpetX_Interpolate LANGUAGE C
 #  CCTK_POINTER ARRAY IN output_arrays)
 #USES FUNCTION SymmetryInterpolate
 
-void FUNCTION MultiPatch_GlobalToLocal( \
+void FUNCTION MultiPatch_GlobalToLocal2( \
   CCTK_INT IN npoints, \
   CCTK_REAL ARRAY IN globalsx, \
   CCTK_REAL ARRAY IN globalsy, \
@@ -149,7 +149,7 @@ void FUNCTION MultiPatch_GlobalToLocal( \
   CCTK_REAL ARRAY OUT localsx, \
   CCTK_REAL ARRAY OUT localsy, \
   CCTK_REAL ARRAY OUT localsz)
-USES FUNCTION MultiPatch_GlobalToLocal
+USES FUNCTION MultiPatch_GlobalToLocal2
 
 CCTK_INT FUNCTION DriverInterpolate(
   CCTK_POINTER_TO_CONST IN cctkGH,

--- a/CarpetX/src/interpolate.cxx
+++ b/CarpetX/src/interpolate.cxx
@@ -401,8 +401,8 @@ extern "C" void CarpetX_Interpolate(const CCTK_POINTER_TO_CONST cctkGH_,
   const cGH *restrict const cctkGH = static_cast<const cGH *>(cctkGH_);
   assert(in_global_mode(cctkGH));
 
-  static const bool have_MultiPatch_GlobalToLocal =
-      CCTK_IsFunctionAliased("MultiPatch_GlobalToLocal");
+  static const bool have_MultiPatch_GlobalToLocal2 =
+      CCTK_IsFunctionAliased("MultiPatch_GlobalToLocal2");
 
   // Convert global to patch-local coordinates
   // TODO: Call this only if there is a non-trivial patch system
@@ -412,10 +412,10 @@ extern "C" void CarpetX_Interpolate(const CCTK_POINTER_TO_CONST cctkGH_,
   std::vector<CCTK_REAL> localsx(npoints);
   std::vector<CCTK_REAL> localsy(npoints);
   std::vector<CCTK_REAL> localsz(npoints);
-  if (have_MultiPatch_GlobalToLocal) {
-    MultiPatch_GlobalToLocal(npoints, globalsx, globalsy, globalsz,
-                             patches.data(), localsx.data(), localsy.data(),
-                             localsz.data());
+  if (have_MultiPatch_GlobalToLocal2) {
+    MultiPatch_GlobalToLocal2(npoints, globalsx, globalsy, globalsz,
+                              patches.data(), localsx.data(), localsy.data(),
+                              localsz.data());
   } else {
     // TODO: Don't copy
     for (int n = 0; n < npoints; ++n) {


### PR DESCRIPTION
This avoids a clash with existing Einstein Toolkit function names.