### PR TITLE
add arraygroupsize overloaded function to support (global) Fortran scheduled functions

### DIFF
--- a/TestArrayGroup/schedule.ccl
+++ b/TestArrayGroup/schedule.ccl
@@ -16,7 +16,25 @@ SCHEDULE TestArrayGroup_Compare AT PostInitial
   READS: test_gf(everywhere)
 } "Test data in grid functions, scalars, and distrib=const arrays"
 
+SCHEDULE TestArrayGroup_CompareF AT PostInitial
+{
+  LANG: Fortran
+  # no local support so far
+  OPTION: global
+  READS: test_scalar(everywhere)
+  READS: test_array(everywhere)
+} "Test data in grid scalars and distrib=const arrays"
+
 SCHEDULE TestArrayGroup_DynamicData AT PostInitial
 {
   LANG: C
 } "Test DynamicData for grid functions, scalars, and distrib=const arrays"
+
+SCHEDULE TestArrayGroup_DynamicDataF AT PostInitial
+{
+  LANG: Fortran
+  # no local support so far
+  OPTION: global
+  READS: test_scalar(everywhere)
+  READS: test_array(everywhere)
+} "Test DynamicData for Fortran scalars, and distrib=const arrays"

--- a/TestArrayGroup/src/TestArray.F90
+++ b/TestArrayGroup/src/TestArray.F90
@@ -1,0 +1,65 @@
+#include <cctk.h>
+#include <cctk_Parameters.h>
+#include <cctk_Arguments.h>
+
+subroutine TestArrayGroup_CompareF(CCTK_ARGUMENTS)
+  DECLARE_CCTK_PARAMETERS
+  DECLARE_CCTK_ARGUMENTS
+
+  !// test array group
+  integer, parameter :: imax = 5
+  integer, parameter :: jmax = 6
+  integer, parameter :: nmax = 4
+  integer, parameter :: size = imax * jmax * nmax
+
+  integer :: array_error_count(3)
+  integer :: scalar_error_count
+
+  integer :: i,j,n
+  character*256 :: warnline
+
+  array_error_count = (/0,0,0/)
+  do n = 1,nmax
+    do j = 1,jmax
+      do i = 1,imax
+        ! -1 is due to data being filled by C code counting from 0
+        if (test1(i,j,n) /= 1 + (i-1) * (j-1) * (n-1)) then
+          array_error_count(1) = array_error_count(1) + 1
+        end if
+        if (test2(i,j,n) /= 1 + 7 * (i-1) * (j-1) * (n-1)) then
+          array_error_count(2) = array_error_count(2) + 1
+        end if
+        if (test3(i,j,n) /= 1 + 13 * (i-1) * (j-1) * (n-1)) then
+          array_error_count(3) = array_error_count(3) + 1
+        end if
+      end do 
+    end do
+  end do
+
+  if (array_error_count(1) > 0) then
+    write(warnline, "('TestArrayGroup: Fortran grid array test1 failed in ', i3, ' of ', i3, ' elements')") array_error_count(1), size
+    call CCTK_ERROR(warnline)
+  end if
+
+  if (array_error_count(2) > 0) then
+    write(warnline, "('TestArrayGroup: Fortran grid array test2 failed in ', i3, ' of ', i3, ' elements')") array_error_count(2), size
+    call CCTK_ERROR(warnline)
+  end if
+
+  if (array_error_count(3) > 0) then
+    write(warnline, "('TestArrayGroup: Fortran grid array test3 failed in ', i3, ' of ', i3, ' elements')") array_error_count(3), size
+    call CCTK_ERROR(warnline)
+  end if
+
+  ! test grid scalar
+  scalar_error_count = 0
+
+  if(test_scalar /= 1) then
+    scalar_error_count = scalar_error_count + 1
+  end if
+
+  if (scalar_error_count > 0) then
+    write(warnline, "('TestArrayGroup: Fortran grid scalr test_scalar failed in ', i3, ' of ', i3, ' elements')") scalar_error_count, 1
+    call CCTK_ERROR(warnline)
+  end if
+end subroutine TestArrayGroup_CompareF

--- a/TestArrayGroup/src/TestDynamicData.F90
+++ b/TestArrayGroup/src/TestDynamicData.F90
@@ -1,0 +1,31 @@
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+
+subroutine TestArrayGroup_DynamicDataF(CCTK_ARGUMENTS)
+  DECLARE_CCTK_PARAMETERS
+  DECLARE_CCTK_ARGUMENTS
+
+  ! Validate grid array dynamic data
+  if(RANK(test1) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
+      call CCTK_ERROR("incorrect dimension in test1 array dynamic data")
+  endif
+  if(SIZE(test1, 1) /= 5 .or. SIZE(test1, 2) /= 6 .or. SIZE(test1, 3) /= 4) then
+      call CCTK_ERROR("incorrect size in test1 array dynamic data")
+  endif
+
+  if(RANK(test2) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
+      call CCTK_ERROR("incorrect dimension in test2 array dynamic data")
+  endif
+  if(SIZE(test2, 1) /= 5 .or. SIZE(test2, 2) /= 6 .or. SIZE(test2, 3) /= 4) then
+      call CCTK_ERROR("incorrect size in test2 array dynamic data")
+  endif
+
+  if(RANK(test3) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
+      call CCTK_ERROR("incorrect dimension in test3 array dynamic data")
+  endif
+  if(SIZE(test3, 1) /= 5 .or. SIZE(test3, 2) /= 6 .or. SIZE(test3, 3) /= 4) then
+      call CCTK_ERROR("incorrect size in test3 array dynamic data")
+  endif
+
+end subroutine TestArrayGroup_DynamicDataF

--- a/TestArrayGroup/src/make.code.defn
+++ b/TestArrayGroup/src/make.code.defn
@@ -3,7 +3,9 @@
 # Source files in this directory
 SRCS =						\
 	TestArray.cxx \
-	TestDynamicData.cxx
+	TestArray.F90 \
+	TestDynamicData.cxx \
+	TestDynamicData.F90
 
 # Subdirectories containing source files
 SUBDIRS = 


### PR DESCRIPTION
This makes it possible to schedule Fortran functions and have them receive non-Null pointers for grid variables. options=local functions are still not supported due to a thread race condition about static variables in the auto-generated glue code.