### PR TITLE
HydroBaseX: Add RHS quantities for the Avec variables

### DIFF
--- a/HydroBaseX/interface.ccl
+++ b/HydroBaseX/interface.ccl
@@ -24,6 +24,10 @@ CCTK_REAL Ye TYPE=gf CENTERING={ccc} TAGS='checkpoint="no"' "electron fraction Y
 
 CCTK_REAL Bvec TYPE=gf CENTERING={ccc} TAGS='parities={+1 -1 -1   -1 +1 -1   -1 -1 +1} checkpoint="no"' { Bvecx Bvecy Bvecz } "Magnetic field B^i"
 
-CCTK_REAL Avecx TYPE=gf CENTERING={cvv} TAGS='parities={-1 +1 +1} checkpoint="no"' "Magnetic vector potential A^x"
-CCTK_REAL Avecy TYPE=gf CENTERING={vcv} TAGS='parities={+1 -1 +1} checkpoint="no"' "Magnetic vector potential A^y"
-CCTK_REAL Avecz TYPE=gf CENTERING={vvc} TAGS='parities={+1 +1 -1} checkpoint="no"' "Magnetic vector potential A^z"
+CCTK_REAL Avecx TYPE=gf CENTERING={cvv} TAGS='parities={-1 +1 +1} rhs="Avecx_rhs" checkpoint="no"' "Magnetic vector potential A^x"
+CCTK_REAL Avecy TYPE=gf CENTERING={vcv} TAGS='parities={+1 -1 +1} rhs="Avecy_rhs" checkpoint="no"' "Magnetic vector potential A^y"
+CCTK_REAL Avecz TYPE=gf CENTERING={vvc} TAGS='parities={+1 +1 -1} rhs="Avecz_rhs" checkpoint="no"' "Magnetic vector potential A^z"
+
+CCTK_REAL Avecx_rhs TYPE=gf CENTERING={cvv} TAGS='checkpoint="no"' "x-component of vector potential RHS"
+CCTK_REAL Avecy_rhs TYPE=gf CENTERING={vcv} TAGS='checkpoint="no"' "y-component of vector potential RHS"
+CCTK_REAL Avecz_rhs TYPE=gf CENTERING={vvc} TAGS='checkpoint="no"' "z-component of vector potential RHS"

--- a/HydroBaseX/schedule.ccl
+++ b/HydroBaseX/schedule.ccl
@@ -39,5 +39,8 @@ if (CCTK_EQUALS(initial_hydro, "vacuum")) {
     WRITES: Avecx(everywhere)
     WRITES: Avecy(everywhere)
     WRITES: Avecz(everywhere)
+    WRITES: Avecx_rhs(everywhere)
+    WRITES: Avecy_rhs(everywhere)
+    WRITES: Avecz_rhs(everywhere)
   } "Set up vacuum initial data"
 }

--- a/HydroBaseX/src/hydrobase.cxx
+++ b/HydroBaseX/src/hydrobase.cxx
@@ -30,13 +30,13 @@ extern "C" void HydroBaseX_initial_data(CCTK_ARGUMENTS) {
 
   grid.loop_all_device<1, 0, 0>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecx(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecx(p.I) = 0; Avecx_rhs(p.I) = 0; });
   grid.loop_all_device<0, 1, 0>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecy(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecy(p.I) = 0; Avecy_rhs(p.I) = 0; });
   grid.loop_all_device<0, 0, 1>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecz(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecz(p.I) = 0; Avecz_rhs(p.I) = 0; });
 }
 
 } // namespace HydroBaseX


### PR DESCRIPTION
Since Avec is an evolved variable, we require its RHS grid functions. More importantly, the Avec variables should depend on the these RHS quantities. Thus, the TAGS for these variables have been updated accordingly.