### PR TITLE
add CarpetX interpolator to list of localinterps known to Cactus

### DIFF
--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -2301,6 +2301,11 @@ extern "C" int CarpetX_Startup() {
   CCTK_OverloadInterpGridArrays(CarpetX_InterpGridArrays);
   CCTK_OverloadArrayGroupSizeB(ArrayGroupSizeB);
   CCTK_OverloadGroupDynamicData(GroupDynamicData);
+
+  iret = CCTK_InterpRegisterOpLocalUniform(InterpLocalUniform, "CarpetX",
+                                           CCTK_THORNSTRING);
+  assert(!iret && "CCTK_InterpRegisterOpLocalUniform failed");
+
   return 0;
 }
 

--- a/CarpetX/src/interp.hxx
+++ b/CarpetX/src/interp.hxx
@@ -22,4 +22,24 @@ extern "C" CCTK_INT CarpetX_DriverInterpolate(
     CCTK_INT const N_output_arrays, CCTK_INT const output_array_type_codes[],
     CCTK_POINTER const output_arrays[]);
 
+namespace CarpetX {
+// a dummy routine for now
+// TODO: implement this for actual local interpolation
+int InterpLocalUniform(int N_dims, int param_table_handle,
+                       /***** coordinate system *****/
+                       const CCTK_REAL coord_origin[],
+                       const CCTK_REAL coord_delta[],
+                       /***** interpolation points *****/
+                       int N_interp_points, int interp_coords_type_code,
+                       const void *const interp_coords[],
+                       /***** input arrays *****/
+                       int N_input_arrays, const CCTK_INT input_array_dims[],
+                       const CCTK_INT input_array_type_codes[],
+                       const void *const input_arrays[],
+                       /***** output arrays *****/
+                       int N_output_arrays,
+                       const CCTK_INT output_array_type_codes[],
+                       void *const output_arrays[]);
+} // namespace CarpetX
+
 #endif // #ifndef CARPETX_CARPETX_INTERP_HXX

--- a/CarpetX/src/interpolate.cxx
+++ b/CarpetX/src/interpolate.cxx
@@ -307,6 +307,25 @@ template <typename T, int order, int centering> struct interpolator {
 
 } // namespace
 
+int InterpLocalUniform(int /*N_dims*/, int /*param_table_handle*/,
+                       /***** coordinate system *****/
+                       const CCTK_REAL /*coord_origin*/[],
+                       const CCTK_REAL /*coord_delta*/[],
+                       /***** interpolation points *****/
+                       int /*N_interp_points*/, int /*interp_coords_type_code*/,
+                       const void *const /*interp_coords*/[],
+                       /***** input arrays *****/
+                       int /*N_input_arrays*/,
+                       const CCTK_INT /*input_array_dims*/[],
+                       const CCTK_INT /*input_array_type_codes*/[],
+                       const void *const /*input_arrays*/[],
+                       /***** output arrays *****/
+                       int /*N_output_arrays*/,
+                       const CCTK_INT /*output_array_type_codes*/[],
+                       void *const /*output_arrays*/[]) {
+  CCTK_ERROR("Dummy InterpLocalUniform function called");
+}
+
 extern "C" CCTK_INT CarpetX_InterpGridArrays(
     cGH const *const cctkGH, int const N_dims, int const local_interp_handle,
     int const param_table_handle, int const coord_system_handle,
@@ -341,6 +360,15 @@ extern "C" CCTK_INT CarpetX_DriverInterpolate(
     CCTK_INT const N_output_arrays, CCTK_INT const output_array_type_codes[],
     CCTK_POINTER const output_arrays[]) {
   DECLARE_CCTK_PARAMETERS;
+
+  // We do not support local interpolators yet
+  const int carpetx_interp_handle = CCTK_InterpHandle("CarpetX");
+  assert(carpetx_interp_handle >= 0);
+  if (carpetx_interp_handle != local_interp_handle) {
+    CCTK_VERROR("Incorrect local interpolator handle provided, only 'CarpetX' "
+                "is allowed: %d != %d",
+                local_interp_handle, carpetx_interp_handle);
+  }
 
   // This verifies that the order in param_table_handle matches the order of the
   // runtime parameter from CarpetX

--- a/TestInterpolate/src/test_interpolation.cxx
+++ b/TestInterpolate/src/test_interpolation.cxx
@@ -99,7 +99,10 @@ extern "C" void TestInterpolate_test_interpolation(CCTK_ARGUMENTS) {
   CCTK_INT const coord_system_handle = 0;
   CCTK_INT const interp_coords_type_code = 0;
   CCTK_INT const output_array_type_codes[1] = {0};
-  int interp_handle = 0;
+  int interp_handle = CCTK_InterpHandle("CarpetX");
+
+  if(interp_handle < 0)
+    CCTK_VERROR("Could not obtain inteprolator handle for built-in 'CarpetX' interpolator: %d", interp_handle);
 
   /* Table generation */
   int operands[DIM(all_operations)][DIM(all_varinds)];


### PR DESCRIPTION
This adds a "CarpetX" local interpolator name to Cactus list of interpolators, so that client code can request an interpolator handle from `CCTK_InterpHandle` to pass to `CCTK_InterpGridArrays`. The actual handle is checked for and is the only one allowed. This prepares client code for a future full integration of the CarpetX interpolator with Cactus.