### PR TITLE
CarpetX: print min and max norm on stdout

### DIFF
--- a/CarpetX/src/io_norm.cxx
+++ b/CarpetX/src/io_norm.cxx
@@ -215,6 +215,10 @@ void OutputNorms(const cGH *restrict cctkGH) {
           for (int d = 0; d < dim; ++d)
             file << sep << red.maxloc[d];
         }
+        
+      printf("Output norm %s: min = %15.6e, max = %15.6e\n", CCTK_FullVarName(groupdata.firstvarindex + vi), red.min, red.max);  
+
+        
       }
     }
 


### PR DESCRIPTION
The min and max is printed every time out_norm is called. Min/max printed for all variables listed in 'out_norm_vars'