### PR TITLE
CarpetX: fix bug in hermite prolongation

### DIFF
--- a/CarpetX/src/prolongate_3d_rf2.hxx
+++ b/CarpetX/src/prolongate_3d_rf2.hxx
@@ -462,20 +462,20 @@ extern prolongate_3d_rf2<CC, CC, CC, MINMOD, MINMOD, MINMOD, 1, 1, 1, FB_NONE>
 
 // Hermite interpolation
 
-extern prolongate_3d_rf2<VC, VC, VC, HERMITE, HERMITE, HERMITE, 1, 1, 1,
+extern prolongate_3d_rf2<VC, VC, VC, POLY, POLY, POLY, 1, 1, 1,
                          FB_NONE>
     prolongate_hermite_3d_rf2_c000_o1;
-extern prolongate_3d_rf2<VC, VC, CC, HERMITE, HERMITE, CONS, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<VC, VC, CC, POLY, POLY, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c001_o1;
-extern prolongate_3d_rf2<VC, CC, VC, HERMITE, CONS, HERMITE, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<VC, CC, VC, POLY, CONS, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c010_o1;
-extern prolongate_3d_rf2<VC, CC, CC, HERMITE, CONS, CONS, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<VC, CC, CC, POLY, CONS, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c011_o1;
-extern prolongate_3d_rf2<CC, VC, VC, CONS, HERMITE, HERMITE, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<CC, VC, VC, CONS, POLY, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c100_o1;
-extern prolongate_3d_rf2<CC, VC, CC, CONS, HERMITE, CONS, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<CC, VC, CC, CONS, POLY, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c101_o1;
-extern prolongate_3d_rf2<CC, CC, VC, CONS, CONS, HERMITE, 1, 1, 1, FB_NONE>
+extern prolongate_3d_rf2<CC, CC, VC, CONS, CONS, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c110_o1;
 extern prolongate_3d_rf2<CC, CC, CC, CONS, CONS, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c111_o1;

--- a/CarpetX/src/prolongate_3d_rf2_impl_hermite.cxx
+++ b/CarpetX/src/prolongate_3d_rf2_impl_hermite.cxx
@@ -4,19 +4,19 @@ namespace CarpetX {
 
 // Hermite interpolation
 
-prolongate_3d_rf2<VC, VC, VC, HERMITE, HERMITE, HERMITE, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<VC, VC, VC, POLY, POLY, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c000_o1;
-prolongate_3d_rf2<VC, VC, CC, HERMITE, HERMITE, CONS, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<VC, VC, CC, POLY, POLY, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c001_o1;
-prolongate_3d_rf2<VC, CC, VC, HERMITE, CONS, HERMITE, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<VC, CC, VC, POLY, CONS, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c010_o1;
-prolongate_3d_rf2<VC, CC, CC, HERMITE, CONS, CONS, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<VC, CC, CC, POLY, CONS, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c011_o1;
-prolongate_3d_rf2<CC, VC, VC, CONS, HERMITE, HERMITE, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<CC, VC, VC, CONS, POLY, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c100_o1;
-prolongate_3d_rf2<CC, VC, CC, CONS, HERMITE, CONS, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<CC, VC, CC, CONS, POLY, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c101_o1;
-prolongate_3d_rf2<CC, CC, VC, CONS, CONS, HERMITE, 1, 1, 1, FB_NONE>
+prolongate_3d_rf2<CC, CC, VC, CONS, CONS, POLY, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c110_o1;
 prolongate_3d_rf2<CC, CC, CC, CONS, CONS, CONS, 1, 1, 1, FB_NONE>
     prolongate_hermite_3d_rf2_c111_o1;


### PR DESCRIPTION
This PR is trying to fix bug in the Hermite type of prolongation.

1. Since the first order Hermite interpolation is the same with Lagrange Interpolation and quit different from higher Hermite interpolations, we removed that coeffs and calling POLY directly for first order Hermite.
2. We update the coeffs for higher Hermite interpolation according to the derivation here: https://github.com/lwJi/Docs-CarpetX-Public/blob/main/notes/Prolongation/Hermite.ipynb
3. We update the size the stencils required by Hermite because it's two points larger compared to the same order Lagrangian.