### PR TITLE
CarpetX: Check timers before changing their state

### DIFF
--- a/CarpetX/src/timer.cxx
+++ b/CarpetX/src/timer.cxx
@@ -16,7 +16,9 @@ Timer::Timer(const std::string &name)
 void Timer::start() {
 #pragma omp critical
   {
-    CCTK_TimerStartI(handle);
+    if (!CCTK_TimerIsRunningI(handle)) {
+      CCTK_TimerStartI(handle);
+    }
 #ifdef __CUDACC__
     range = nvtxRangeStartA(name.c_str());
 #endif
@@ -29,7 +31,9 @@ void Timer::stop() {
 #ifdef __CUDACC__
     nvtxRangeEnd(range);
 #endif
-    CCTK_TimerStopI(handle);
+    if (CCTK_TimerIsRunningI(handle)) {
+      CCTK_TimerStopI(handle);
+    }
   }
 }
 


### PR DESCRIPTION
In some situations, adding `CarpetX` timer objects to scheduled functions may cause the flesh to issue warnings about the timer state, i.e., warnings against starting timers that are already started or stopping timers that are already stopped.

This PR checks the state of the underlying `Cactus` timer before starting or stopping them to prevent such warnings.