### PR TITLE
HydroBaseX: HydroBase feature porting, Aphi GF, conditional storage and inits.

### DIFF
--- a/HydroBaseX/interface.ccl
+++ b/HydroBaseX/interface.ccl
@@ -27,3 +27,5 @@ CCTK_REAL Bvec TYPE=gf CENTERING={ccc} TAGS='parities={+1 -1 -1   -1 +1 -1   -1 
 CCTK_REAL Avecx TYPE=gf CENTERING={cvv} TAGS='parities={-1 +1 +1} checkpoint="no"' "Magnetic vector potential A^x"
 CCTK_REAL Avecy TYPE=gf CENTERING={vcv} TAGS='parities={+1 -1 +1} checkpoint="no"' "Magnetic vector potential A^y"
 CCTK_REAL Avecz TYPE=gf CENTERING={vvc} TAGS='parities={+1 +1 -1} checkpoint="no"' "Magnetic vector potential A^z"
+
+CCTK_REAL Aphi TYPE=gf CENTERING={vvv} TAGS='checkpoint="no"' "Electric potential for Lorentz gauge"

--- a/HydroBaseX/param.ccl
+++ b/HydroBaseX/param.ccl
@@ -6,3 +6,70 @@ KEYWORD initial_hydro "Initial conditions for hydro"
 {
   "vacuum" :: "vacuum (without atmosphere)"
 } "vacuum"
+
+KEYWORD evolution_method "The hydro evolution method"
+{
+  "none" :: "hydro variables are not evolved"
+} "none"
+
+# Settings for electron fraction Y_e
+
+KEYWORD initial_Y_e "Initial value for Y_e"
+{
+  "none" :: "inactive"
+  "one"  :: "initially set to one"
+} "none"
+
+KEYWORD Y_e_evolution_method "Evolution method for Y_e"
+{
+  "none" :: "Evolution for Y_e is disabled"
+} "none"
+
+KEYWORD temperature_evolution_method "Evolution method for temperature"
+{
+  "none" :: "Evolution for temperature is disabled"
+} "none"
+
+KEYWORD entropy_evolution_method "Evolution method for entropy"
+{
+  "none" :: "Evolution for entropy is disabled"
+} "none"
+
+# Settings for magnetic field B^i
+
+KEYWORD initial_Bvec "Initial value for Bvec"
+{
+  "none" :: "inactive"
+  "zero" :: "initially set to zero"
+} "none"
+
+KEYWORD initial_Avec "Initial value for Avec"
+{
+  "none" :: "inactive"
+  "zero" :: "initially set to zero"
+} "none"
+
+KEYWORD initial_Aphi "Initial value for Aphi"
+{
+  "none" :: "inactive"
+  "zero" :: "initially set to zero"
+} "none"
+
+KEYWORD Bvec_evolution_method "Evolution method for Bvec"
+{
+  "none" :: "Evolution for Bvec is disabled"
+} "none"
+
+# Settings for temperature and entropy
+
+KEYWORD initial_temperature "Initial value for temperature"
+{
+  "none" :: "inactive"
+  "zero" :: "initially set to zero"
+} "none"
+
+KEYWORD initial_entropy "Initial value for entropy"
+{
+  "none" :: "inactive"
+  "zero" :: "initially set to zero"
+} "none"

--- a/HydroBaseX/schedule.ccl
+++ b/HydroBaseX/schedule.ccl
@@ -1,5 +1,36 @@
 # Schedule definitions for thorn HydroBaseX
 
+STORAGE: rho
+STORAGE: press
+STORAGE: eps
+STORAGE: vel
+if (!CCTK_EQUALS(initial_Y_e, "none"))
+{
+  STORAGE: Ye
+}
+if (!CCTK_EQUALS(initial_Bvec, "none"))
+{
+  STORAGE: Bvec
+}
+if (!CCTK_EQUALS(initial_Avec, "none"))
+{
+  STORAGE: Avecx
+  STORAGE: Avecy
+  STORAGE: Avecz
+}
+if (!CCTK_EQUALS(initial_Aphi, "none"))
+{
+  STORAGE: Aphi
+}
+if (!CCTK_EQUALS(initial_temperature, "none"))
+{
+  STORAGE: temperature
+}
+if (!CCTK_EQUALS(initial_entropy, "none"))
+{
+  STORAGE: entropy
+}
+
 if (CCTK_IsThornActive("ODESolvers")) {
 
   SCHEDULE GROUP HydroBaseX_InitialData IN ODESolvers_Initial
@@ -42,22 +73,70 @@ if (CCTK_IsThornActive("ODESolvers")) {
 
 }
 
-
-
-if (CCTK_EQUALS(initial_hydro, "vacuum")) {
-  SCHEDULE HydroBaseX_initial_data IN HydroBaseX_InitialData
+if (CCTK_EQUALS(initial_hydro, "vacuum"))
+{
+  SCHEDULE HydroBaseX_Zero IN HydroBaseX_InitialData
   {
     LANG: C
     WRITES: rho(everywhere)
     WRITES: vel(everywhere)
     WRITES: eps(everywhere)
     WRITES: press(everywhere)
+  } "Set up vacuum hydro initial data"
+}
+
+if (CCTK_Equals(initial_temperature, "zero"))
+{
+  SCHEDULE HydroBaseX_temperature_zero IN HydroBaseX_InitialData
+  {
+    LANG: C
     WRITES: temperature(everywhere)
+  } "Set temperature to 0"
+}
+
+if (CCTK_Equals(initial_entropy, "zero"))
+{
+  SCHEDULE HydroBaseX_entropy_zero IN HydroBaseX_InitialData
+  {
+    LANG: C
     WRITES: entropy(everywhere)
+  } "Set entropy to 0"
+}
+
+if (CCTK_Equals(initial_Y_e, "one"))
+{
+  SCHEDULE HydroBaseX_Y_e_one IN HydroBaseX_InitialData
+  {
+    LANG: C
     WRITES: Ye(everywhere)
+  } "Set electron fraction to 1"
+}
+
+if (CCTK_Equals(initial_Bvec, "zero"))
+{
+  SCHEDULE HydroBaseX_Bvec_zero IN HydroBaseX_InitialData
+  {
+    LANG: C
     WRITES: Bvec(everywhere)
+  } "Set magnetic field to 0"
+}
+
+if (CCTK_Equals(initial_Avec, "zero"))
+{
+  SCHEDULE HydroBaseX_Avec_zero IN HydroBaseX_InitialData
+  {
+    LANG: C
     WRITES: Avecx(everywhere)
     WRITES: Avecy(everywhere)
     WRITES: Avecz(everywhere)
-  } "Set up vacuum initial data"
+  } "Set vector potential to 0"
+}
+
+if (CCTK_Equals(initial_Aphi, "zero"))
+{
+  SCHEDULE HydroBaseX_Aphi_zero IN HydroBaseX_InitialData
+  {
+    LANG: C
+    WRITES: Aphi(everywhere)
+  } "Set vector potential Phi to 0"
 }

--- a/HydroBaseX/src/hydrobase.cxx
+++ b/HydroBaseX/src/hydrobase.cxx
@@ -7,36 +7,88 @@
 namespace HydroBaseX {
 using namespace Loop;
 
-extern "C" void HydroBaseX_initial_data(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_initial_data;
+extern "C" void HydroBaseX_Zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_Zero;
   DECLARE_CCTK_PARAMETERS;
 
   grid.loop_all_device<1, 1, 1>(grid.nghostzones,
                                 [=] CCTK_DEVICE(const PointDesc &p)
                                     CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                      rho(p.I) = 0;
-                                      velx(p.I) = 0;
-                                      vely(p.I) = 0;
-                                      velz(p.I) = 0;
-                                      eps(p.I) = 0;
-                                      press(p.I) = 0;
-                                      temperature(p.I) = 0;
-                                      entropy(p.I) = 0;
-                                      Ye(p.I) = 0;
-                                      Bvecx(p.I) = 0;
-                                      Bvecy(p.I) = 0;
-                                      Bvecz(p.I) = 0;
+                                      rho(p.I) = 0.0;
+                                      velx(p.I) = 0.0;
+                                      vely(p.I) = 0.0;
+                                      velz(p.I) = 0.0;
+                                      eps(p.I) = 0.0;
+                                      press(p.I) = 0.0;
                                     });
+}
+
+extern "C" void HydroBaseX_temperature_zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_temperature_zero;
+  DECLARE_CCTK_PARAMETERS;
+
+  grid.loop_all_device<1, 1, 1>(
+      grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                              temperature(p.I) = 0.0;
+                            });
+}
+
+extern "C" void HydroBaseX_entropy_zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_entropy_zero;
+  DECLARE_CCTK_PARAMETERS;
+
+  grid.loop_all_device<1, 1, 1>(
+      grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                              entropy(p.I) = 0.0;
+                            });
+}
+
+extern "C" void HydroBaseX_Y_e_one(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_Y_e_one;
+  DECLARE_CCTK_PARAMETERS;
+
+  grid.loop_all_device<1, 1, 1>(
+      grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Ye(p.I) = 1.0; });
+}
+
+extern "C" void HydroBaseX_Bvec_zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_Bvec_zero;
+  DECLARE_CCTK_PARAMETERS;
+
+  grid.loop_all_device<1, 1, 1>(grid.nghostzones,
+                                [=] CCTK_DEVICE(const PointDesc &p)
+                                    CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                      Bvecx(p.I) = 0.0;
+                                      Bvecy(p.I) = 0.0;
+                                      Bvecz(p.I) = 0.0;
+                                    });
+}
+
+extern "C" void HydroBaseX_Avec_zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_Avec_zero;
+  DECLARE_CCTK_PARAMETERS;
 
   grid.loop_all_device<1, 0, 0>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecx(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecx(p.I) = 0.0; });
   grid.loop_all_device<0, 1, 0>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecy(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecy(p.I) = 0.0; });
   grid.loop_all_device<0, 0, 1>(
       grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
-                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecz(p.I) = 0; });
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecz(p.I) = 0.0; });
+}
+
+extern "C" void HydroBaseX_Aphi_zero(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_HydroBaseX_Aphi_zero;
+  DECLARE_CCTK_PARAMETERS;
+
+  grid.loop_all_device<0, 0, 0>(
+      grid.nghostzones, [=] CCTK_DEVICE(const PointDesc &p)
+                            CCTK_ATTRIBUTE_ALWAYS_INLINE { Aphi(p.I) = 0.0; });
 }
 
 } // namespace HydroBaseX


### PR DESCRIPTION
Move HydroBaseX closer to a true HydroBase/Carpet port by adding the missing optional initialization parameters: `initial_Y_e`, `*_Bvec`, `*_Avec`, `*_Aphi`, `*_temperature`, and `*_entropy`. These parameters declare which thorn provides each optional field, with HydroBaseX handling the built-in zero/one initialization cases.

Add Aphi as a HydroBaseX GF with AsterX-consistent vvv centering. This is the electric potential, which rounds out the EM support with Bvec, Avec, and Aphi all being treated consistently.

Add zeroing routines for Bvec, Avec, Aphi, temperature, and entropy, and add the Y_e one routine.

Rho, press, eps, and vel are always stored, while the remaining optional fields are now only stored conditionally, consistent with HydroBase's treatment.