### PR TITLE
ADMBaseX: Evolution parameters to match ADMBase and conditional storage

### DIFF
--- a/ADMBaseX/param.ccl
+++ b/ADMBaseX/param.ccl
@@ -25,15 +25,38 @@ KEYWORD initial_dtlapse "Initial dtlapse value"
 {
   "none" :: "Do not set up initial conditions"
   "zero" :: "Dtlapse is zero"
-} "zero"
+} "none"
 
 KEYWORD initial_dtshift "Initial dtshift value"
 {
   "none" :: "Do not set up initial conditions"
   "zero" :: "Dtshift is zero"
-} "zero"
+} "none"
 
+KEYWORD evolution_method "The metric an extrinsic curvature evolution method"
+{
+  "none" :: "The metric and extrinsic curvature are not evolved"
+} "none"
 
+KEYWORD lapse_evolution_method "The lapse evolution method"
+{
+  "none" :: "lapse is not evolved"
+} "none"
+
+KEYWORD shift_evolution_method "The shift evolution method"
+{
+  "none" :: "shift is not evolved"
+} "none"
+
+KEYWORD dtlapse_evolution_method "The dtlapse evolution method"
+{
+  "none" :: "dtlapse is not evolved"
+} "none"
+
+KEYWORD dtshift_evolution_method "The dtshift evolution method"
+{
+  "none" :: "dtshift is not evolved"
+} "none"
 
 PRIVATE:
 

--- a/ADMBaseX/schedule.ccl
+++ b/ADMBaseX/schedule.ccl
@@ -1,5 +1,23 @@
 # Schedule definitions for thorn ADMBaseX
 
+STORAGE: lapse
+STORAGE: metric curv
+
+if (! CCTK_Equals(initial_shift, "none"))
+{
+  STORAGE: shift
+}
+
+if (! CCTK_Equals(initial_dtlapse, "none"))
+{
+  STORAGE: dtlapse
+}
+
+if (! CCTK_Equals(initial_dtshift, "none"))
+{
+  STORAGE: dtshift
+}
+
 if (CCTK_IsThornActive("ODESolvers")) {
 
   SCHEDULE GROUP ADMBaseX_InitialData IN ODESolvers_Initial
@@ -107,6 +125,9 @@ if (CCTK_EQUALS(initial_dtshift, "zero")) {
 
 
 if (noise_amplitude != 0) {
+if (! CCTK_Equals(initial_dtlapse, "none")) {
+if (! CCTK_Equals(initial_shift, "none")) {
+if (! CCTK_Equals(initial_dtshift, "none")) {
   # TODO: Also add noise during evolution?
   # TODO: Noise should be added by a separate thorn.
 
@@ -132,4 +153,5 @@ if (noise_amplitude != 0) {
     SYNC: shift
     SYNC: dtshift
   } "Add noise to ADMBaseX variables"
+}}}
 }


### PR DESCRIPTION
Add bookkeeping evolution parameters, default dtlapse and dtshift off, conditional storage, porting of ADMBase features.

Store lapse, metric, and curv by default, while shift, dtlapse, and dtshift are now conditional on their initial_* parameters. This restores conditional storage behavior for the optional ADM fields.

Change the default to both dtlapse and dtshift disabled, which was the ADMBase default behavior, this may have some consequences on existing test and parfiles.

This PR is similiar but smaller in scope to another PR adapting the same features to HydroBaseX, #385. 

