### PR TITLE
Feature/any all

### DIFF
--- a/Arith/src/vect.hxx
+++ b/Arith/src/vect.hxx
@@ -810,6 +810,7 @@ template <typename T, int D> struct nan<vect<T, D> > {
   }
 };
 
+
 // Defined at namespace scope rather than as hidden friends inside vect
 // to work around an nvcc bug where ADL fails to resolve hidden-friend
 // all/any (observed with nvcc 12.6 through 13.1 + g++ 13).
@@ -830,7 +831,6 @@ any(const vect<T, D> &x) {
     r = r || x[d];
   return r;
 }
-
 } // namespace Arith
 namespace std {
 template <typename T, int D> struct equal_to<Arith::vect<T, D> > {

--- a/Arith/src/vect.hxx
+++ b/Arith/src/vect.hxx
@@ -819,6 +819,29 @@ template <typename T, int D> struct nan<vect<T, D> > {
   }
 };
 
+// Namespace-scope overloads of all/any for vect.
+// On conforming compilers the hidden friends inside vect win overload
+// resolution (non-template beats template). On nvcc, whose ADL is
+// broken for these names, normal unqualified lookup finds these
+// templates instead. No call sites need to change.
+template <typename T, int D>
+constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto
+all(const vect<T, D> &x) {
+  auto r = one<T>()();
+  for (int d = 0; d < D; ++d)
+    r = r && x[d];
+  return r;
+}
+
+template <typename T, int D>
+constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto
+any(const vect<T, D> &x) {
+  auto r = zero<T>()();
+  for (int d = 0; d < D; ++d)
+    r = r || x[d];
+  return r;
+}
+
 } // namespace Arith
 namespace std {
 template <typename T, int D> struct equal_to<Arith::vect<T, D> > {

--- a/Arith/src/vect.hxx
+++ b/Arith/src/vect.hxx
@@ -626,17 +626,8 @@ template <typename T, int D> struct vect {
     return fmap([](const T &a) ARITH_INLINE { return abs(a); }, x);
   }
 
-  friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto /*bool*/
-  all(const vect &x) {
-    return fold([](const T &a, const T &b) ARITH_INLINE { return a && b; },
-                one<T>()(), x);
-  }
-
-  friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto /*bool*/
-  any(const vect &x) {
-    return fold([](const T &a, const T &b) ARITH_INLINE { return a || b; },
-                zero<T>()(), x);
-  }
+  // all/any are defined at namespace scope (after the struct) to work
+  // around an nvcc ADL bug that fails to resolve hidden friends.
 
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto /*bool*/
   allisfinite(const vect &x) {
@@ -819,11 +810,9 @@ template <typename T, int D> struct nan<vect<T, D> > {
   }
 };
 
-// Namespace-scope overloads of all/any for vect.
-// On conforming compilers the hidden friends inside vect win overload
-// resolution (non-template beats template). On nvcc, whose ADL is
-// broken for these names, normal unqualified lookup finds these
-// templates instead. No call sites need to change.
+// Defined at namespace scope rather than as hidden friends inside vect
+// to work around an nvcc bug where ADL fails to resolve hidden-friend
+// all/any (observed with nvcc 12.6 through 13.1 + g++ 13).
 template <typename T, int D>
 constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST auto
 all(const vect<T, D> &x) {

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -279,7 +279,7 @@ struct carpetx_openpmd_t {
         return true;
       if (x.empty() || y.empty())
         return false;
-      return Arith::all(x.lo == y.lo) && Arith::all(x.hi == y.hi);
+      return all(x.lo == y.lo) && all(x.hi == y.hi);
     }
     constexpr friend bool operator!=(const box_t &x, const box_t &y) {
       return !(x == y);

--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -279,12 +279,12 @@ struct carpetx_openpmd_t {
         return true;
       if (x.empty() || y.empty())
         return false;
-      return all(x.lo == y.lo) && all(x.hi == y.hi);
+      return Arith::all(x.lo == y.lo) && Arith::all(x.hi == y.hi);
     }
     constexpr friend bool operator!=(const box_t &x, const box_t &y) {
       return !(x == y);
     }
-    constexpr bool empty() const { return any(hi < lo); }
+    constexpr bool empty() const { return Arith::any(hi < lo); }
     constexpr Arith::vect<T, D> shape() const {
       Arith::vect<T, D> sh;
       for (std::size_t d = 0; d < D; ++d)
@@ -1248,7 +1248,7 @@ void carpetx_openpmd_t::InputOpenPMD(const cGH *const cctkGH,
                   for (int j = extbox.lo[1]; j < extbox.hi[1]; ++j) {
                     for (int i = extbox.lo[0]; i < extbox.hi[0]; ++i) {
                       const Arith::vect<int, dim> I{i, j, k};
-                      if (any(I < box.lo || I >= box.hi))
+                      if (Arith::any(I < box.lo || I >= box.hi))
                         memcpy(cactus_var_ptr + (cactus_di * i + cactus_dj * j +
                                                  cactus_dk * k) *
                                                     vartypesize,


### PR DESCRIPTION
This PR allows the code despite a compiler bug in cuda 12.9.1 https://bitbucket.org/einsteintoolkit/tickets/issues/2922/carpetx-does-not-compile-with-cuda-129

It moves any/all to namespaces and fully qualifies their use in a few cases.